### PR TITLE
v1.1.0

### DIFF
--- a/Etch.OrchardCore.ContextualEdit.csproj
+++ b/Etch.OrchardCore.ContextualEdit.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <PackageId>Etch.OrchardCore.ContextualEdit</PackageId>
     <Title>Contextual Edit</Title>
     <Authors>Etch</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -5,6 +5,6 @@ using OrchardCore.Modules.Manifest;
     Category = "Content",
     Description = "Widget for displaying edit control for page being viewed.",
     Name = "Contextual Edit",
-    Version = "1.0.0",
+    Version = "1.1.0",
     Website = "https://etchuk.com"
 )]

--- a/Views/ContextualEditPart.cshtml
+++ b/Views/ContextualEditPart.cshtml
@@ -1,21 +1,21 @@
-﻿@model Etch.OrchardCore.ContextualEdit.ViewModels.ContextualEditPartDisplayViewModel
-
-<div class="editor-toolbar">
+﻿<div class="editor-toolbar js-editor-toolbar">
     <div class="editor-toolbar__content">
-        <h3>Viewing @Model.ContentItem.DisplayText</h3>
+        <h3 class="margin--bottom-small text--uppercase">@Model.ContentItem.DisplayText</h3>
         @if (Model.ContentItem.Published)
         {
-            <p>Published by @Model.ContentItem.Author on @Model.ContentItem.PublishedUtc.Value.ToString().</p>
+            <p class="text--size-small font--subheading margin--bottom-none">
+                @T["Published by {0} on {1}.", Model.ContentItem.Author, Model.ContentItem.PublishedUtc.ToString()]
+                <a edit-for="@Model.ContentItem" asp-route-returnUrl="@FullRequestPath" class="link--edit">@T["Edit"] @Model.ContentItem.ContentType</a>
+                <a href="#" onclick="document.querySelector('.js-editor-toolbar').remove(); return false;">Hide</a>
+            </p>
         }
         else
         {
-            <p>Draft</p>
+            <p class="text--size-small font--subheading margin--bottom-none">
+                @T["Draft"].
+                <a edit-for="@Model.ContentItem" asp-route-returnUrl="@FullRequestPath" class="link--edit">@T["Edit"] @Model.ContentItem.ContentType</a>
+                <a href="#" onclick="document.querySelector('.js-editor-toolbar').remove(); return false;">Hide</a>
+            </p>
         }
-
-        <ul class="list list--options">
-            <li class="list__item">
-                <a edit-for="@Model.ContentItem" asp-route-returnUrl="@FullRequestPath">@T["Edit"] @Model.ContentItem.ContentType</a>
-            </li>
-        </ul>
     </div>
 </div>

--- a/Views/_ViewImports.cshtml
+++ b/Views/_ViewImports.cshtml
@@ -1,7 +1,7 @@
 @inherits OrchardCore.DisplayManagement.Razor.RazorPage<TModel>
-    
+
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper *, OrchardCore.Contents
+@addTagHelper *, OrchardCore.Contents.TagHelpers
 @addTagHelper *, OrchardCore.DisplayManagement
 @addTagHelper *, OrchardCore.ResourceManagement
 


### PR DESCRIPTION
Update markup in part template
    
- Update to use markup that's used within the theme boilerplate
- Add ability to hide the contextual edit control (fixes #1)
- Fix `edit-for` link by updating tag helper reference